### PR TITLE
#63: round service bug, chat route rework

### DIFF
--- a/src/controllers/chat.controller.ts
+++ b/src/controllers/chat.controller.ts
@@ -4,6 +4,7 @@ import { IChat } from '../interfaces/chat.interface';
 import HttpException from '../application/utils/exceptions/http-exceptions';
 import HttpStatusCode from '../application/utils/exceptions/statusCode';
 import { RequestWithUser } from '../application/middlewares/authenticateToken';
+import { userService } from '../services/user.service';
 
 class ChatController {
   async getById(req: Request, res: Response): Promise<void> {
@@ -75,14 +76,18 @@ class ChatController {
 
   async view(req: RequestWithUser, res: Response): Promise<void> {
     const id = req.params.id;
+    const user = req.params.userName;
 
     try {
       if (!(await chatService.exists(id))) {
         res.status(HttpStatusCode.NOT_FOUND).send('chat  not found, please check your id');
         return;
+      } else if (!(await userService.existsByUsername(user))) {
+        res.status(HttpStatusCode.NOT_FOUND).send('username not found, please check your username');
+        return;
       }
 
-      res.render('chat', { user: req.user, chatId: req.params.id });
+      res.render('chat', { user: user, chatId: req.params.id });
     } catch (error) {
       if (error instanceof HttpException) {
         res.status(error.status).json({ error: error.message });

--- a/src/controllers/game.controller.ts
+++ b/src/controllers/game.controller.ts
@@ -5,10 +5,7 @@ import { IGameCreateSchema } from '../interfaces/game.interface';
 import { gameService } from '../services/game.service';
 import HttpException from '../application/utils/exceptions/http-exceptions';
 
-export async function create(
-  req: RequestWithUser,
-  res: Response,
-): Promise<Response | void> {
+export async function create(req: RequestWithUser, res: Response): Promise<Response | void> {
   const game = {
     teams: req.body.teams,
     hostId: req.user!._id,
@@ -19,34 +16,23 @@ export async function create(
   return res.status(HttpStatusCode.CREATED).json(await gameService.getById(id));
 }
 
-export async function getById(
-  req: RequestWithUser,
-  res: Response,
-): Promise<Response | void> {
+export async function getById(req: RequestWithUser, res: Response): Promise<Response | void> {
   //TODO add members access validation
   const id: string = req.params.id;
   const game = await gameService.getById(id);
   return res.status(HttpStatusCode.OK).json(game);
 }
 
-export async function start(
-  req: RequestWithUser,
-  res: Response,
-): Promise<Response | void> {
+export async function start(req: RequestWithUser, res: Response): Promise<Response | void> {
   const id: string = req.params.id;
   const user = req.user;
   const game = await gameService.getById(id);
   if (game.hostId === user?._id) {
     const chatId = await gameService.start(id);
-    return res.send(chatId).status(HttpStatusCode.OK);
-  } else {
     return res
-      .status(HttpStatusCode.UNAUTHORIZED)
-      .json(
-        new HttpException(
-          HttpStatusCode.UNAUTHORIZED,
-          'Only game host can start game.',
-        ),
-      );
+      .send(`Link to chat: http://localhost:3000/api/v1/chats/${chatId}/view/${user.username}`)
+      .status(HttpStatusCode.OK);
+  } else {
+    return res.status(HttpStatusCode.UNAUTHORIZED).json(new HttpException(HttpStatusCode.UNAUTHORIZED, 'Only game host can start game.'));
   }
 }

--- a/src/routes/chat.router.ts
+++ b/src/routes/chat.router.ts
@@ -9,6 +9,6 @@ chatRouter.post('/', authenticateToken, chatController.create);
 chatRouter.patch('/:id', authenticateToken, chatController.update);
 chatRouter.delete('/:id', authenticateToken, chatController.delete);
 
-chatRouter.get('/:id/view', chatController.view);
+chatRouter.get('/:id/view/:userName', chatController.view);
 
 export default chatRouter;

--- a/src/services/game.service.ts
+++ b/src/services/game.service.ts
@@ -76,16 +76,13 @@ class GameService {
     return rounds.some(round => round.words.map(obj => obj.word).includes(word));
   }
 
-  async start(id: string): Promise<{ msg: string; chatId: string }> {
+  async start(id: string): Promise<string> {
     await gameRepository.start(id);
     const game = await this.getById(id);
     const { roundId, chatId } = await this.createRound(game);
     game.rounds.push(roundId);
     await this.update(game);
-    return {
-      msg: `proceed to chat with chatId:${chatId}. Link: http://localhost:3000/api/v1/chats/${chatId}/view`,
-      chatId,
-    };
+    return chatId
   }
 
   private async createRound(game: IGame): Promise<{ roundId: string; chatId: string }> {

--- a/src/services/round.service.ts
+++ b/src/services/round.service.ts
@@ -1,10 +1,11 @@
-import {roundRepository} from '../repositories/round.repository';
-import {IRound, IRoundCreateSchema} from '../interfaces/round.interface';
-import {gameService} from './game.service';
-import {userService} from "./user.service";
-import HttpException from "../application/utils/exceptions/http-exceptions";
-import HttpStatusCode from "../application/utils/exceptions/statusCode";
-import {teamService} from "./team.service";
+import { roundRepository } from '../repositories/round.repository';
+import { IRound, IRoundCreateSchema } from '../interfaces/round.interface';
+import { gameService } from './game.service';
+import { userService } from './user.service';
+import HttpException from '../application/utils/exceptions/http-exceptions';
+import HttpStatusCode from '../application/utils/exceptions/statusCode';
+import { teamService } from './team.service';
+import { chatService } from './chat.service';
 
 class RoundService {
   async getById(id: string): Promise<IRound> {
@@ -24,15 +25,15 @@ class RoundService {
   async create(round: IRoundCreateSchema): Promise<string> {
     const hostExists = await userService.exists(round.hostId);
     if (!hostExists) {
-      throw new HttpException(HttpStatusCode.NOT_FOUND, "Host of round is not found.");
+      throw new HttpException(HttpStatusCode.NOT_FOUND, 'Host of round is not found.');
     }
     const teamExists = await teamService.exists(round.teamId);
     if (!teamExists) {
-      throw new HttpException(HttpStatusCode.NOT_FOUND, "Team of round is not found.");
+      throw new HttpException(HttpStatusCode.NOT_FOUND, 'Team of round is not found.');
     }
-    const chatExists = await userService.exists(round.chatId);
+    const chatExists = await chatService.exists(round.chatId);
     if (!chatExists) {
-      throw new HttpException(HttpStatusCode.NOT_FOUND, "Chat of round is not found.");
+      throw new HttpException(HttpStatusCode.NOT_FOUND, 'Chat of round is not found.');
     }
     return roundRepository.create(round);
   }

--- a/src/views/chat.ejs
+++ b/src/views/chat.ejs
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Chat</title>
-    <link rel="stylesheet" type="text/css" href="/chat.css">
+    <link rel="stylesheet" type="text/css" href="/chat.css" />
   </head>
   <body>
     <div id="chat-container">
@@ -14,11 +14,6 @@
       <!-- Form for sending messages -->
       <form id="form" action="">
         <input id="input" autocomplete="off" placeholder="Type your message" />
-        <input
-          id="username-input"
-          autocomplete="off"
-          placeholder="Your username"
-        />
         <button id="send-button">Send</button>
       </form>
     </div>
@@ -26,18 +21,19 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.js"></script>
     <script>
       const path = window.location.pathname;
-      const match = path.match(/\/chats\/([^/]+)\/view/);
+      const match = path.match(/\/chats\/([^/]+)\/view\/([^/]+)$/);
       const chatId = match ? match[1] : null;
+      const username = match ? match[2] : null;
 
       const socket = io();
+
       if (chatId) {
-        socket.emit('join', chatId);
+        socket.emit('join', { chatId, username });
       } else {
         console.error('Chat ID is missing in the URL');
       }
 
       const messages = document.getElementById('messages');
-      const usernameInput = document.getElementById('username-input');
       const form = document.getElementById('form');
       const input = document.getElementById('input');
 
@@ -45,12 +41,12 @@
         e.preventDefault();
         if (input.value && chatId) {
           const message = input.value.trim().toLowerCase();
-          const username = usernameInput.value.trim();
 
           if (message.startsWith('clear-messages-admin')) {
             socket.emit('admin clear messages', chatId);
             input.value = '';
           } else if (username) {
+            console.log(`${username}: ${message} : ${chatId}`);
             socket.emit('chat message', `${username}: ${message}`, chatId);
             input.value = '';
           }


### PR DESCRIPTION
Fixed bug about roundservice calling userService to verify if chat exists.

Rework chat - now it will have username in route instead of manually typing.

it will look like this and it will give an error if username not in DB:

```http://localhost:3000/api/v1/chats/2b69239b8f4fcad17d1787b5660002f7/view/testName```

what do you think? I've had an idea that its better to pass accessToken and verify it instead of passing username in route.